### PR TITLE
fix ember-get-config import not always working due to missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "ember-cli-htmlbars": "^3.0.0",
     "ember-concurrency": "^0.8.25",
     "ember-concurrency-test-waiter": "^0.3.1",
+    "ember-get-config": "^0.2.4",
     "ember-infinity": "^1.3.1",
     "ember-power-select": "^2.2.1"
   },
@@ -57,7 +58,6 @@
     "ember-data": "~3.8.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
-    "ember-get-config": "^0.2.4",
     "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-mirage-sauce": "git+https://github.com/nickschot/ember-mirage-sauce.git#fixes",


### PR DESCRIPTION
`ember-get-config` was a devDep instead of a dep.