### PR TITLE
Bugfix to enable usage of query and search propery at the same time

### DIFF
--- a/addon/components/model-select.js
+++ b/addon/components/model-select.js
@@ -289,7 +289,7 @@ export default Component.extend({
       const searchProperty = this.get('searchProperty');
       const searchKey = this.get('searchKey') || this.get('labelProperty');
 
-      const searchObj = get(query, `${searchProperty}.${searchKey}`) || {};
+      const searchObj = get(query, `${searchProperty}`) || {};
       set(searchObj, searchKey, term);
       set(query, searchProperty, searchObj);
     }


### PR DESCRIPTION
The additional filter (or every other `searchProperty`) will be overwritten by the default `searchProperty`, so you can't add an extra filter to the query. Current code sets the value of `searchKey` to the `searchProperty`.

The current code doesn't actually merge the search parameters into the query. Lines 292 & 293 result in setting `query[searchProperty][searchKey][searchKey]` to the search term and setting `query[searchProperty][searchKey]` on `query[searchProperty]`

Code:
```
searchProperty='filter'
searchKey='code_cont'
query= { filter: { id_not_in: [ 1, 2, 3 ] } }
```

Result:
```
query = { filter: { 'code_cont': typedValue } }
```

Expected result:
```
query = { filter: {
  code_cont: typedValue,
  id_not_in: [ 1, 2, 3 ]
}  }
```

